### PR TITLE
Enable build checks on pull requests

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: ["main"]
 
+  # Run workflow for pull request events to verify build
+  pull_request:
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -82,6 +85,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from 'next/navigation';
-import Image from 'next/image';
 import ReactMarkdown from 'react-markdown';
-import { getPost } from '@/lib/posts';
+import { getPost, getPosts } from '@/lib/posts';
 
 export default async function BlogPost({ params }: any) {
   const post = await getPost(params.slug).catch(() => null);
@@ -29,4 +28,9 @@ export default async function BlogPost({ params }: any) {
       </article>
     </main>
   );
+}
+
+export async function generateStaticParams() {
+  const posts = await getPosts();
+  return posts.map((post) => ({ slug: post.slug }));
 }


### PR DESCRIPTION
## Summary
- trigger the Next.js workflow on pull_request events
- skip GitHub Pages deployment when the workflow runs for a PR

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fed6389ac8325aea69e69969bee16