### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,11 @@
   }
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeToggle from "@/components/theme-toggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <div className="fixed top-4 right-4 z-10">
+          <ThemeToggle />
+        </div>
         {children}
       </body>
     </html>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const shouldUseDark = stored === 'dark' || (!stored && prefersDark)
+    if (shouldUseDark) {
+      document.documentElement.classList.add('dark')
+      setIsDark(true)
+    }
+  }, [])
+
+  const toggle = () => {
+    const html = document.documentElement
+    if (html.classList.contains('dark')) {
+      html.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+      setIsDark(false)
+    } else {
+      html.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+      setIsDark(true)
+    }
+  }
+
+  return (
+    <button onClick={toggle} className="p-2 border rounded">
+      {isDark ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/**/*.{ts,tsx}',
     './posts/**/*.md'


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- support `.dark` theme colors
- add `ThemeToggle` component
- show toggle button in layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff1184f7c8325b29502865670a7a1